### PR TITLE
added hadoop 2.7.2 to resources and wrapped properties var in try

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,7 @@ from the [Gobblin wiki](https://github.com/linkedin/gobblin/wiki)
 This charm is uses the Hadoob base layer and the HDFS interface to pull its dependencies
 and act as a client to a Hadoop namenode. Here is how to deploy the Hadoop infrastructure:
 
-    juju deploy apache-hadoop-datanode datanode
-    juju deploy apache-hadoop-namenode namenode
-    juju deploy apache-hadoop-nodemanager nodemgr
-    juju deploy apache-hadoop-resourcemanager resourcemgr
-    juju deploy apache-hadoop-plugin plugin
-
-    juju add-relation namenode datanode
-    juju add-relation resourcemgr nodemgr
-    juju add-relation resourcemgr namenode
-    juju add-relation plugin resourcemgr
-    juju add-relation plugin namenode
-
+    juju quickstart apache-processing-mapreduce
 
 Deploy the Gobblin charm and relate it to tha neme node:
  
@@ -37,12 +26,13 @@ From the Gobblin unit, start the wikipedia ingestion demo job as the `gobblin` u
     cd /tmp
     sudo su gobblin -c "gobblin-mapreduce.sh --conf wikipedia.pull --jars /usr/lib/gobblin/lib/gobblin-example.jar"
 
-The output will be in hdfs under /user/gobblin/work/job-output/gobblin/example/wikipedia/WikipediaOutput/<Your_Job_Id> . You can set the output directory through the ``--workdir`` flag. 
+The output will be in hdfs under /user/gobblin/work/job-output/gobblin/example/wikipedia/WikipediaOutput/<Your_Job_Id> .
+You can set the output directory through the ``--workdir`` flag. 
 
-List and get the job output file in avro format.
+List and get the job output file(s) in avro format.
 
     hdfs dfs -ls /user/gobblin/work/job-output/gobblin/example/wikipedia/WikipediaOutput/<Your_Job_Id>
-    hdfs dfs -get /user/gobblin/work/job-output/gobblin/example/wikipedia/WikipediaOutput/<Your_Job_Id>/<Output.avro>
+    hdfs dfs -get /user/gobblin/work/job-output/gobblin/example/wikipedia/WikipediaOutput/<Your_Job_Id>/<Path_To_Output>/<Output.avro>
 
 Transform to JSON.
 

--- a/layer.yaml
+++ b/layer.yaml
@@ -10,3 +10,4 @@ options:
         path: '/usr/lib/gobblin'
         owner: 'gobblin'
         group: 'hadoop'
+    silent: True

--- a/lib/charms/layer/gobblin.py
+++ b/lib/charms/layer/gobblin.py
@@ -62,7 +62,10 @@ class Gobblin(object):
         conf_dir = self.dist_config.path('gobblin') / 'conf'
         gobblin_config_template = conf_dir / 'gobblin-mapreduce.properties.template'
         gobblin_config = conf_dir / 'gobblin-mapreduce.properties'
-        copy(gobblin_config_template, gobblin_config)
+        try:
+            copy(gobblin_config_template, gobblin_config)
+        except FileNotFoundError:
+            pass
 
         utils.re_edit_in_place(gobblin_config, {
             r'fs.uri=hdfs://localhost:8020': 'fs.uri=hdfs://%s' % hdfs_endpoint,

--- a/lib/charms/layer/gobblin.py
+++ b/lib/charms/layer/gobblin.py
@@ -13,6 +13,7 @@ class Gobblin(object):
     """
     def __init__(self, hadoop_version, dist_config):
         self.dist_config = dist_config
+        self.hadoop_version = hadoop_version
         self.cpu_arch = utils.cpu_arch()
 
         self.resources = {
@@ -70,3 +71,8 @@ class Gobblin(object):
         utils.re_edit_in_place(gobblin_config, {
             r'fs.uri=hdfs://localhost:8020': 'fs.uri=hdfs://%s' % hdfs_endpoint,
         })
+
+        if '2.7.2' in self.hadoop_version:
+            utils.re_edit_in_place(gobblin_config, {
+                r'task.data.root.dir=*': 'task.data.root.dir=${env:GOBBLIN_WORK_DIR}/task'
+            }, append_non_matches=True)

--- a/resources.yaml
+++ b/resources.yaml
@@ -1,7 +1,12 @@
 options:
   output_dir: /home/ubuntu/resources
 optional_resources:
+  gobblin-hadoop_2.7.2-x86_64:
+    url: https://s3.amazonaws.com/jujubigdata/linkedin/x86_64/gobblin-dist-0.6.0_hadoop-2.7.2-aa9fd90.tar.gz
+    hash: aa9fd908faf6821fc00a04b4b6c4ec90759a9cbb0f0771d9ee9a1ea684f5d79e
+    hash_type: sha256
   gobblin-hadoop_2.7.1-x86_64:
     url: https://s3.amazonaws.com/jujubigdata/linkedin/x86_64/gobblin-dist-0.5.0_hadoop-2.7.1-aa91339.tar.gz
     hash: aa9133984ca1c1409e9227fa0f7f6cd7ea5640ba61f5dbb5813ee4f9a33f0511
     hash_type: sha256
+


### PR DESCRIPTION
Gobblin 0.6.0 now doesnt include a template file so wrapped the copy block in a try.

Unfortunately, there are now new issues (see issues for this repo) such as the output types, and the missing parameter in the properties file.
